### PR TITLE
Fix alacritty deprecations

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,8 +1,9 @@
+[general]
 import = [
     "~/.config/alacritty/themes/themes/tokyo-night.toml"
 ]
 
-[shell]
+[terminal.shell]
 program = "/usr/bin/fish"
 
 [colors]


### PR DESCRIPTION
Fix the following deprecations introduced by alacritty:
1. ``import`` -> ``general.import``
2. ``shell.program`` -> ``terminal.shell.program``